### PR TITLE
Modernize WinForms startup initialization

### DIFF
--- a/NCAA_XDBE/Program.cs
+++ b/NCAA_XDBE/Program.cs
@@ -11,8 +11,7 @@ namespace DB_EDITOR
         [STAThread]
         static void Main()
         {
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
+            ApplicationConfiguration.Initialize();
             Application.Run(new MainEditor());
         }
     }


### PR DESCRIPTION
## Summary
- Replace legacy WinForms startup with `ApplicationConfiguration.Initialize()`
- Remove obsolete `EnableVisualStyles` and `SetCompatibleTextRenderingDefault`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68a796aa2f388329a9b909f8cda4eee6