### PR TITLE
Remove legacy bootstrappers and document modern publish

### DIFF
--- a/NCAA_XDBE/NCAA_XDBE.csproj
+++ b/NCAA_XDBE/NCAA_XDBE.csproj
@@ -375,28 +375,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include=".NETFramework,Version=v4.0,Profile=Client">
-      <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4 Client Profile %28x86 and x64%29</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Windows.Installer.3.1">
-      <Visible>False</Visible>
-      <ProductName>Windows Installer 3.1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-  </ItemGroup>
+  <PropertyGroup>
+    <!-- Use modern ClickOnce tooling with dotnet publish -->
+    <PublishProtocol>ClickOnce</PublishProtocol>
+    <PublishDir>publish\</PublishDir>
+  </PropertyGroup>
   <ItemGroup>
     <None Include="Resources\players\BMI-Calc.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ DB/Save Editor for NCAA Football series on PS2/Xbox/PSP/GC Consoles
 This editor was designed using original source code from Madden Xtreme DB Editor (elguapo) and MaddenAMP (Colin Goudie/stringray68) and uses tdbaccess library from Artem Khassanov of NHLView.
 
 
+## Deployment
+
+Publish the application using the modern tooling with:
+
+```bash
+dotnet publish NCAA_XDBE/NCAA_XDBE.csproj -c Release
+```
+
+The ClickOnce package is created in the `publish/` directory.
+
 # New Features
 * Added better compatibility with NCAA PS2 Games and PS2 in general
 * Ability to view, edit and save NCAA off-season save files  (click Options, Load Off-Season Save, Reload save file)


### PR DESCRIPTION
## Summary
- remove obsolete BootstrapperPackage definitions from the project file
- configure project for modern ClickOnce deployment via `dotnet publish`
- document publishing instructions in README

## Testing
- `dotnet publish NCAA_XDBE/NCAA_XDBE.csproj -c Release` *(fails: dotnet not installed)*
- `apt-get update` *(fails: repositories unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68a796abf8b883299471e0da80984dd7