### PR TITLE
Add net8 project file with tdbaccess resource

### DIFF
--- a/NCAA_XDBE/NCAA_XDBE.net8.csproj
+++ b/NCAA_XDBE/NCAA_XDBE.net8.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="Resources\tdbaccess.dll" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add new .NET 8 project file
- ensure tdbaccess.dll copies to output

## Testing
- `dotnet build NCAA_XDBE/NCAA_XDBE.net8.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a796acc0fc8329855852a723a1aa65