### PR TITLE
Clarify assembly info handling

### DIFF
--- a/NCAA_XDBE/NCAA_XDBE.csproj
+++ b/NCAA_XDBE/NCAA_XDBE.csproj
@@ -30,6 +30,7 @@
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <PlatformTarget>x86</PlatformTarget>

--- a/NCAA_XDBE/Properties/AssemblyInfo.cs
+++ b/NCAA_XDBE/Properties/AssemblyInfo.cs
@@ -1,20 +1,14 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
+// General assembly metadata
 [assembly: AssemblyTitle("NCAA Xtreme DB Editor")]
 [assembly: AssemblyDescription("Updated for NCAA Football by Antdroid. " +
     "\n\r\n\r\n\rCredits:\n\r\n\r\n* elguapo: Madden Xtreme DB Editor Source code. \n\r\n\r" +
     "* Stingray68: MaddenAmp Source Code\n\r\n\r" + "* JDHalfrack: DAT File Replacer + more!\n\r\n\r" + "* Colin Goudie: MaddenAmp\n\r\n\r" +
     "* Artem Khassanov: tdbaccess.dll")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("NCAA Xtreme DB Editor")]
 [assembly: AssemblyCopyright("Copyright © 2019 - 2025")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
@@ -24,15 +18,4 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("d1068195-ca21-4ccf-8198-e273ad8743f4")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.*")]
-//[assembly: AssemblyFileVersion("0.0.0.0")]


### PR DESCRIPTION
## Summary
- set GenerateAssemblyInfo to false to retain custom assembly metadata
- remove redundant AssemblyInfo attributes

## Testing
- `dotnet build NCAA_XDBE/NCAA_XDBE.csproj` *(fails: command not found)*
- `apt-get update` *(fails: 403 repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a796adfdec8329bf7ab4f97c0e1ab6